### PR TITLE
fix: use correct id for contentful link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Contentful Commerce by Commerce Layer](/public/assets//header-light.png#gh-light-mode-only)
 ![Contentful Commerce by Commerce Layer](/public/assets//header-dark.png#gh-dark-mode-only)
 
-[![Install to Contentful](https://www.ctfstatic.com/button/install-small.svg)](https://app.contentful.com/deeplink?link=apps&id=contentful-commerce&referrer=commercelayer)
+[![Install to Contentful](https://www.ctfstatic.com/button/install-small.svg)](https://app.contentful.com/deeplink?link=apps&id=5AuHBmPgmRNIwuxHhVu9PD&referrer=commercelayer)
 
 ## Introduction
 


### PR DESCRIPTION
## What I did

Update the id of the app after I moved it under the CL Contentful org.

## How to test

Click on the "Add to Contentful" link and it should take you to the install page.

## Checklist

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
